### PR TITLE
APIのアップデートに伴うコードの修正

### DIFF
--- a/examples/image_influence_api.py
+++ b/examples/image_influence_api.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-import pya3rt
-
-apikey = "{YOUR_API_KEY}"
-client = pya3rt.ImageInfluenceClient(apikey)
-
-print(client.get_upload_url())
-print(client.meat_score("meat1.jpeg", 1))
-

--- a/pya3rt/client.py
+++ b/pya3rt/client.py
@@ -7,33 +7,22 @@ from .image_influence import ImageInfluence
 from .listing import Listing
 
 ENDPOINTS = {
-    'text_suggest': 'https://api.a3rt.recruit-tech.co.jp/text_suggest/v2/predict',
+    'text_suggest': 'https://api.a3rt.recruit.co.jp/text_suggest/v2/predict',
     'text_classification': {
-        'classify': 'https://api.a3rt.recruit-tech.co.jp/text_classification/v1/classify',
-        'dataset': 'https://api.a3rt.recruit-tech.co.jp/text_classification/v1/dataset',
-        'model': 'https://api.a3rt.recruit-tech.co.jp/text_classification/v1/model',
-        'check_status': 'https://api.a3rt.recruit-tech.co.jp/text_classification/v1/check_status',
+        'classify': 'https://api.a3rt.recruit.co.jp/text_classification/v1/classify',
+        'dataset': 'https://api.a3rt.recruit.co.jp/text_classification/v1/dataset',
+        'model': 'https://api.a3rt.recruit.co.jp/text_classification/v1/model',
+        'check_status': 'https://api.a3rt.recruit.co.jp/text_classification/v1/check_status',
     },
     'listing': {
-        'get_upload_url': 'https://api.a3rt.recruit-tech.co.jp/listing/v1/get_upload_url',
-        'start_w2v': 'https://api.a3rt.recruit-tech.co.jp/listing/v1/start_w2v',
-        'status_w2v': 'https://api.a3rt.recruit-tech.co.jp/listing/v1/status_w2v',
-        'get_download_url': 'https://api.a3rt.recruit-tech.co.jp/listing/v1/get_download_url',
-        'cancel_w2v': 'https://api.a3rt.recruit-tech.co.jp/listing/v1/cancel_w2v',
+        'get_upload_url': 'https://api.a3rt.recruit.co.jp/listing/v1/get_upload_url',
+        'start_w2v': 'https://api.a3rt.recruit.co.jp/listing/v1/start_w2v',
+        'status_w2v': 'https://api.a3rt.recruit.co.jp/listing/v1/status_w2v',
+        'get_download_url': 'https://api.a3rt.recruit.co.jp/listing/v1/get_download_url',
+        'cancel_w2v': 'https://api.a3rt.recruit.co.jp/listing/v1/cancel_w2v',
     },
-    'image_influence': {
-        'scoring': {
-            'meat_score': 'https://api.a3rt.recruit-tech.co.jp/image_influence/v1/meat_score',
-            'image_score': 'https://api.a3rt.recruit-tech.co.jp/image_influence/v1/image_score',
-        },
-        'model': {
-            'get_upload_url': 'https://api.a3rt.recruit-tech.co.jp/image_influence/v1/get_upload_url',
-            'order_model': 'https://api.a3rt.recruit-tech.co.jp/image_influence/v1/order_model',
-            'status_model': 'https://api.a3rt.recruit-tech.co.jp/image_influence/v1/status_model',
-        },
-    },
-    'proofreading': 'https://api.a3rt.recruit-tech.co.jp/proofreading/v2/typo',
-    'talk': 'https://api.a3rt.recruit-tech.co.jp/talk/v1/smalltalk',
+    'proofreading': 'https://api.a3rt.recruit.co.jp/proofreading/v2/typo',
+    'talk': 'https://api.a3rt.recruit.co.jp/talk/v1/smalltalk',
 }
 
 
@@ -119,38 +108,6 @@ class ProofreadingClient(object):
         endpoint = self.endpoint
         apikey = self.apikey
         return Proofreading.request(endpoint, apikey, sentence, callback, sensitivity)
-
-
-class ImageInfluenceClient(object):
-
-    def __init__(self, apikey):
-        self.apikey = apikey
-        self.endpoint = ENDPOINTS['image_influence']
-
-    def meat_score(self, imagefile, predict):
-        endpoint = self.endpoint['scoring']['meat_score']
-        apikey = self.apikey
-        return ImageInfluence.meat_score(endpoint, apikey, imagefile, predict)
-
-    def image_score(self, imagefile, predict):
-        endpoint = self.endpoint['scoring']['image_score']
-        apikey = self.apikey
-        return ImageInfluence.image_score(endpoint, apikey, imagefile, predict)
-
-    def get_upload_url(self):
-        endpoint = self.endpoint['model']['get_upload_url']
-        apikey = self.apikey
-        return ImageInfluence.get_upload_url(endpoint, apikey)
-
-    def order_model(self):
-        endpoint = self.endpoint['model']['order_model']
-        apikey = self.apikey
-        return ImageInfluence.order_model(endpoint, apikey)
-
-    def status_model(self):
-        endpoint = self.endpoint['model']['status_model']
-        apikey = self.apikey
-        return ImageInfluence.status_model(endpoint, apikey)
 
 
 class TalkClient(object):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
 readme = ''
-with open('README.md') as f:
+with open('README.md', encoding='utf-8_sig') as f:
     readme = f.read()
 
 setup(name='pya3rt',


### PR DESCRIPTION
2021年7月19日にA3RT公式サイトでお知らせがあったAPIのアップデートに伴い、以下の修正を行いました。

- APIのドメイン変更（`a3rt.recruit-tech.co.jp` → `a3rt.recruit.co.jp`）
- Image Influence APIの廃止に伴い、該当のAPIをリクエストしているコードの削除

以下、[公式サイト](https://a3rt.recruit.co.jp/)のアナウンスからの引用です。

> 2021年7月19日
> 【ドメイン変更及び提供終了機能について】
> 
> <ドメイン変更に伴うアプリ修正依頼>
> 弊社組織変更に伴い、ドメインが変更となります。
> 　旧ドメイン）a3rt.recruit-tech.co.jp
> 　新ドメイン）a3rt.recruit.co.jp
> 2021年9月30日までは併用期間として両方使える状態ですが、2021年10月1日以降、旧ドメインは廃止、新ドメインのみ利用可能となる予定です。
> お手数ですが、ブックマーク、APIコール時のドメイン変更対応をお願いします。
> なお、Image Influence, SQL Suggestの2サービスについては、旧ドメインのみ対応とし、新ドメインでの提供はいたしません。
> 
> <Image Influence, SQL Suggest機能提供終了>
> 上記機能は、2021年9月30日の旧ドメイン停止をもって提供を終了させていただきます。
> 
> サービス側都合での修正依頼・提供終了となり申し訳ございませんが、ご対応のほどよろしくお願いいたします。

また、今回の修正とは別になりますがWindowsで`setup.py`を実行したら、READMEを読み込むときに`UnicodeDecodeError`が出力されたため、open関数のオプションに`encode='utf-8_sig'`を追加しました。
(微修正なのでここで追加しましたが、もし不要な修正であれば取り下げるのでご連絡いただけますと幸いです)

以上、レビューよろしくお願いします。